### PR TITLE
add publicPath to BugsnagSourceMapUploaderPlugin to fix sourcemaps

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -67,7 +67,8 @@ module.exports = function (moduleOptions) {
     config.plugins.push(new BugsnagSourceMapUploaderPlugin({
       apiKey: options.clientConfig.apiKey,
       appVersion: options.clientConfig.appVersion,
-      overwrite: true
+      overwrite: true,
+      publicPath: '*'
     }))
 
     logger.info('Enabling uploading of release sourcemaps to Bugsnag')


### PR DESCRIPTION
Servus :)

add publicPath to BugsnagSourceMapUploaderPlugin in order to have right source map file urls.

instead of /_nuxt/<hash>.js it generates */_nuxt/<hash>.js