### PR TITLE
fix: plugin should be plugins for bugsnag to work

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import Bugsnag from '@bugsnag/js'
 import BugsnagPluginVue from '@bugsnag/plugin-vue'
 const options = <%= serialize(options) %>
-options.plugin = [new BugsnagPluginVue(Vue)]
+options.plugins = [new BugsnagPluginVue(Vue)]
 const bugsnagClient = Bugsnag.start(options)
 
 export default function ({ app }, inject) {


### PR DESCRIPTION
Without this typo fix bugsnag receives no error reporting.