### PR TITLE
Fix modifying nuxt config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -38,6 +38,10 @@ export default defineNuxtModule<ModuleOptions>({
   hooks: {
     'autoImports:extend': (imports) => {
       imports.push({ name: 'useBugsnag', as: 'useBugsnag', from: resolve('./runtime/composables/useBugsnag') })
+    },
+    'vite:extendConfig': (config) => {
+      config.build.sourcemap = 'hidden'
+      config.optimizeDeps.include.push('@bugsnag/plugin-vue')
     }
   },
   setup (options, nuxt) {
@@ -56,11 +60,6 @@ export default defineNuxtModule<ModuleOptions>({
     if (!options.publishRelease || nuxt.options.dev) {
       return
     }
-
-    extendViteConfig((config) => {
-      config.build.sourcemap = 'hidden'
-      config.optimizeDeps.include.push('@bugsnag/plugin-vue')
-    })
 
     nuxt.addHooks({
       'nitro:config': (config) => {


### PR DESCRIPTION
Hi Julian!

I found another Issue. In our project the I still got the Error from #32 and hunted it down to nuxt-vite seems to have changed to hooks. I can't find the code that `extendViteConfig` does not work any more, but the hook seems to work. Not sure if we should set a concrete `nuxt-vite` version as dependency..

See https://github.com/nuxt/vite/issues/4 and https://vite.nuxtjs.org/advanced/modules/