### PR TITLE
fix: optimizing deps if publishRelease is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ You can pass every bugsnag [options](https://docs.bugsnag.com/platforms/javascri
 ```
 
 
-# Source Maps
+### Source Maps
 
 You can upload sourcemaps by adding the option `publishRelease`.
-It's important to set the baseUrl aswell, it will allow bugsnag to map your errors to the sourcemap
+It's important to set the baseUrl as well, it will allow bugsnag to map your errors to the sourcemap:
 
 ```js
 {
@@ -64,6 +64,8 @@ It's important to set the baseUrl aswell, it will allow bugsnag to map your erro
   }
 }
 ```
+
+## Config Example
 
 I would recommend to set these options
 ```js
@@ -84,7 +86,7 @@ I would recommend to set these options
 }
 ```
 
-# Reporting custom errors
+## Reporting custom errors
 The simplest answer is like this.
 ```
 this.$bugsnag.notify(new Error('Some Error'))

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ It's important to set the baseUrl aswell, it will allow bugsnag to map your erro
 ```js
 {
   bugsnag: {
-    config: {
-      publishRelease: true,
-      baseUrl: 'http://localhost:3000'
-    }
+    publishRelease: true,
+    baseUrl: 'http://localhost:3000'
   }
 }
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -66,13 +66,16 @@ export default defineNuxtModule<ModuleOptions>({
 
     addPlugin(resolve('./runtime/plugin'))
 
+    extendViteConfig((config) => {
+      config.optimizeDeps.include.push('@bugsnag/plugin-vue')
+    })
+
     if (!options.publishRelease || nuxt.options.dev) {
       return
     }
 
     extendViteConfig((config) => {
       config.build.sourcemap = 'hidden'
-      config.optimizeDeps.include.push('@bugsnag/plugin-vue')
     })
 
     nuxt.addHooks({


### PR DESCRIPTION
Hi Julian,

last time I overlooked that if `publishRelease` is `false`, `@bugsnag/plugin-vue` won't get optimized. This optimizeDeps has nothing to do with the source maps, so I moved that before that check.