### PR TITLE
feat: make project root configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ I would recommend to set these options
       enabledReleaseStages: ['staging', 'production'],
       releaseStage: process.env.NODE_ENV
       appVersion: 'YOUR_VERSION',
+      projectRoot: '/'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ It's important to set the baseUrl as well, it will allow bugsnag to map your err
 }
 ```
 
+### Setting a different project root
+
+If your Nuxt App runs in a different folder than `/`, you might want to set `projectRoot` to this directory, so that BugSnag can match the sourcemap.
+
 ## Config Example
 
 I would recommend to set these options
@@ -81,13 +85,13 @@ I would recommend to set these options
       enabledReleaseStages: ['staging', 'production'],
       releaseStage: process.env.NODE_ENV
       appVersion: 'YOUR_VERSION',
-      projectRoot: '/'
     }
   }
 }
 ```
 
 ## Reporting custom errors
+
 The simplest answer is like this.
 ```
 this.$bugsnag.notify(new Error('Some Error'))

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,6 +20,7 @@ export interface ModuleOptions {
         notifyReleaseStages?: string[]
         environment?: string
         appVersion?: string
+        projectRoot?: string
       }
     | Partial<BrowserConfig>
 }
@@ -41,7 +42,8 @@ export default defineNuxtModule<ModuleOptions>({
       notifyReleaseStages: [],
       apiKey: '',
       environment: 'production',
-      appVersion: '1.0.0'
+      appVersion: '1.0.0',
+      projectRoot: '/'
     }
   },
   hooks: {
@@ -93,7 +95,7 @@ export default defineNuxtModule<ModuleOptions>({
                 directory: nitro.options.output.serverDir,
                 logger: nitro.logger,
                 overwrite: true,
-                projectRoot: '/'
+                projectRoot: options.config.projectRoot
               })
             )
 


### PR DESCRIPTION
Hey!

We build our assets in a different folder, which is why we have to set `projectRoot` to that folder.