### PR TITLE
Make compatible with nuxt 3.4.0

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,8 +1,11 @@
 import Bugsnag, { BrowserConfig, Client } from '@bugsnag/js'
 import BugsnagPluginVue from '@bugsnag/plugin-vue'
-import { defineNuxtPlugin, isVue2 } from '#app'
+import { defineNuxtPlugin, isVue2, useRuntimeConfig } from '#app'
+import { RuntimeConfig } from '@nuxt/schema'
+
 export default defineNuxtPlugin((nuxtApp) => {
-  const options: BrowserConfig = { ...nuxtApp.payload.config.public.bugsnag }
+  const config: RuntimeConfig = useRuntimeConfig()
+  const options: BrowserConfig = { ...config.public.bugsnag }
 
   options.plugins = [new BugsnagPluginVue()]
   options.onError = (event) => {


### PR DESCRIPTION
Hi there!

Since nuxt 3.4.0 it is not possible to access the runtime config directly. It works via [`useRuntimeconfig()`](https://nuxt.com/docs/guide/going-further/runtime-config#plugins).

This seems not documented in https://github.com/nuxt/nuxt/releases/tag/v3.4.0 .

And this is not fixed in nuxt 3.4.1 which came out two hours ago.