### PR TITLE
Makes `disableLogs` singular like the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The output for a medium Nuxt App can get quite big. So we added an option to dis
 {
   bugsnag: {
     publishRelease: true,
-    disableLogs: true,
+    disableLog: true,
     baseUrl: 'http://localhost:3000'
   }
 }


### PR DESCRIPTION
The docs have it as plural, but the code is a singular `disableLog`