### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Open Stackblitz and [try it out](https://stackblitz.com/edit/nuxt-starter-s5gmvk
 1. Add `nuxt-bugsnag` dependency to your project
 
 ```bash
-npm install nuxt-bugsnag
+npx nuxi@latest module add bugsnag
 ```
 
 2. Add `nuxt-bugsnag` to the `modules` section of `nuxt.config.js`.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
