### PR TITLE
Add pnpm support

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -75,7 +75,7 @@ export default defineNuxtModule<ModuleOptions>({
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
       config.optimizeDeps.include.push(
-        ...['@bugsnag/plugin-vue', '@bugsnag/js']
+        ...["nuxt-bugsnag > @bugsnag/plugin-vue", "nuxt-bugsnag > @bugsnag/js"]
       )
     })
 


### PR DESCRIPTION
In the current version (7.2.3), `@bugsnag/plugin-vue` and `@bugsnag/js` are added to the optimizeDeps list so that the build tool can convert them from CommonJS to ESM in development mode. However, when using pnpm, the dependencies are not hoisted at the root and thus `@bugsnag/plugin-vue` and `@bugsnag/js` are not available. 

The fix for this is specifying the optimizeDeps as nested dependencies of `nuxt-bugsnag`, which was done in this PR.

Please let me know if any changes are required, from my end it seems like this fixes pnpm support.